### PR TITLE
クラス名を&__result-locationに変更

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -52,7 +52,7 @@ body {
     flex-wrap: wrap;
   }
 
-  &__result-place {
+  &__result-location {
     font-weight: 700;
     margin-bottom: 16px;
     flex-basis: 100%;


### PR DESCRIPTION
html内のクラスとマッチしていなかったため